### PR TITLE
Fix #433

### DIFF
--- a/requests_html.py
+++ b/requests_html.py
@@ -564,12 +564,9 @@ class HTML(BaseParser):
         # |      * ``sameSite`` (str): ``'Strict'`` or ``'Lax'``
         cookie_render = {}
         def __convert(cookiejar, key):
-            try:
-                v = eval ("cookiejar."+key)
-                if not v: kv = ''
-                else: kv = {key: v}
-            except:
-                kv = ''
+            v = getattr(cookiejar, key, None)
+            if v is None: kv = ''
+            else: kv = {key: v}
             return kv
 
         keys = [


### PR DESCRIPTION
Now the entry is discarded only if it is `None` or is truly missing and not when its just falsey, like an empty string or 0. Besides, `getattr` is faster and safer.